### PR TITLE
Readme: Fix ref in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ A GitHub Action that allows you to wait for another GitHub check to complete. Th
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           checkName: build
-          ref: github.event.pull_request.head.sha || github.sha
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Do something with a passing build
         if: steps.wait-for-build.outputs.conclusion == 'success'


### PR DESCRIPTION
Instead of using variables the example used the string "github.event.pull_request.head.sha || github.sha " as commit hash, resulting in no such commit errors