### PR TITLE
Use secrets.GITHUB_TOKEN by default as token

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -5,12 +5,12 @@ branding:
   icon: 'check-circle'
   color: 'green'
 inputs:
-  token:
-    description: 'The GitHub token to use for making API requests.'
-    required: true
   checkName:
     description: 'The name of the GitHub check to wait for. For example, `build` or `deploy`.'
     required: true
+  token:
+    description: 'The GitHub token to override GITHUB_TOKEN if needed.'
+    default: ${{ secrets.GITHUB_TOKEN }}
   ref:
     description: 'The Git ref of the commit you want to poll for a passing check.'
   repo:


### PR DESCRIPTION
In most of the cases "secrets.GITHUB_TOKEN" works so no need to pass it.